### PR TITLE
Preserve token casing for engine responses

### DIFF
--- a/pro_metrics.py
+++ b/pro_metrics.py
@@ -6,8 +6,13 @@ TOKEN_RE = re.compile(r"\b\w+\b")
 
 
 def tokenize(text: str):
-    """Split text into lowercase tokens."""
-    return TOKEN_RE.findall(text.lower())
+    """Split text into tokens without altering case."""
+    return TOKEN_RE.findall(text)
+
+
+def lowercase(words):
+    """Return a lowercase copy of tokens for case-insensitive metrics."""
+    return [w.lower() for w in words]
 
 
 def entropy(words):

--- a/pro_rag.py
+++ b/pro_rag.py
@@ -1,14 +1,15 @@
 from typing import List
-from pro_metrics import tokenize
+from pro_metrics import tokenize, lowercase
 import pro_memory
+
 
 async def retrieve(query_words: List[str], limit: int = 5) -> List[str]:
     """Retrieve relevant messages from memory based on word overlap."""
     messages = await pro_memory.fetch_recent(50)
-    qset = set(query_words)
+    qset = set(lowercase(query_words))
     scored = []
     for msg in messages:
-        words = tokenize(msg)
+        words = lowercase(tokenize(msg))
         score = len(qset.intersection(words))
         if score:
             scored.append((score, msg))

--- a/pro_tune.py
+++ b/pro_tune.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import Dict
 
-from pro_metrics import tokenize
+from pro_metrics import tokenize, lowercase
 
 STATE_PATH = 'pro_state.json'
 
@@ -12,7 +12,7 @@ def train(state: Dict, dataset_path: str) -> Dict:
         return state
     with open(dataset_path, 'r', encoding='utf-8') as fh:
         text = fh.read()
-    words = tokenize(text)
+    words = lowercase(tokenize(text))
     wc = state.setdefault('word_counts', {})
     bc = state.setdefault('bigram_counts', {})
     prev = '<s>'

--- a/tests/test_uppercase_preservation.py
+++ b/tests/test_uppercase_preservation.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import asyncio
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pro_memory  # noqa: E402
+import pro_rag  # noqa: E402
+import pro_sequence  # noqa: E402
+from pro_engine import ProEngine  # noqa: E402
+
+
+def test_preserves_uppercase_mid_sentence(monkeypatch):
+    engine = ProEngine()
+
+    async def dummy_add_message(*args, **kwargs):
+        pass
+
+    async def dummy_retrieve(*args, **kwargs):
+        return []
+
+    async def dummy_save_state(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(pro_memory, "add_message", dummy_add_message)
+    monkeypatch.setattr(pro_rag, "retrieve", dummy_retrieve)
+    monkeypatch.setattr(engine, "save_state", dummy_save_state)
+
+    def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(pro_sequence, "analyze_sequences", noop)
+
+    response, _ = asyncio.run(engine.process_message("hello WORLD friend"))
+    assert "WORLD" in response.split()[1:]


### PR DESCRIPTION
## Summary
- keep tokenizer case-sensitive and add helper to lowercase tokens for metrics
- ensure engine carries original word casing through message processing
- add async-unit test confirming uppercase words survive in responses

## Testing
- `flake8 pro_metrics.py pro_engine.py pro_rag.py pro_tune.py tests/test_uppercase_preservation.py`
- `pytest tests/test_uppercase_preservation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d52db87883298a17d06bee18b8a2