### PR TITLE
Preserve capitalization for leading word and extend tests

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -85,7 +85,11 @@ class ProEngine:
             return "Silence echoes within void."
         if len(charged) < 5:
             charged = (charged * 5)[:5]
-        sentence = charged[0].capitalize() + ' ' + ' '.join(charged[1:]) + '.'
+        first = charged[0]
+        if first and first[0].isalpha():
+            first = first[0].upper() + first[1:]
+        words = [first] + charged[1:]
+        sentence = " ".join(filter(None, words)) + "."
         return sentence
 
     async def process_message(self, message: str) -> Tuple[str, Dict]:

--- a/tests/test_uppercase_preservation.py
+++ b/tests/test_uppercase_preservation.py
@@ -2,6 +2,8 @@ import os
 import sys
 import asyncio
 
+import pytest
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import pro_memory  # noqa: E402
@@ -10,7 +12,8 @@ import pro_sequence  # noqa: E402
 from pro_engine import ProEngine  # noqa: E402
 
 
-def test_preserves_uppercase_mid_sentence(monkeypatch):
+@pytest.fixture
+def engine(monkeypatch):
     engine = ProEngine()
 
     async def dummy_add_message(*args, **kwargs):
@@ -31,5 +34,19 @@ def test_preserves_uppercase_mid_sentence(monkeypatch):
 
     monkeypatch.setattr(pro_sequence, "analyze_sequences", noop)
 
+    return engine
+
+
+def test_preserves_uppercase_mid_sentence(engine):
     response, _ = asyncio.run(engine.process_message("hello WORLD friend"))
     assert "WORLD" in response.split()[1:]
+
+
+def test_acronym_first_word(engine):
+    response, _ = asyncio.run(engine.process_message("NASA launches rockets"))
+    assert response.split()[0] == "NASA"
+
+
+def test_mixed_case_first_word(engine):
+    response, _ = asyncio.run(engine.process_message("iPhone release soon"))
+    assert response.split()[0] == "IPhone"


### PR DESCRIPTION
## Summary
- Use manual first-letter uppercasing in responses while preserving remaining characters and handling empty or non-alphabetic words
- Add pytest fixture and new tests for acronym and mixed-case capitalization behavior

## Testing
- `pytest -q`
- `flake8 pro_engine.py tests/test_uppercase_preservation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1d71c3c4883298787f92022c6e1b4