### PR TITLE
Optimize charged word computation and add performance test

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -4,6 +4,7 @@ import os
 import hashlib
 import asyncio
 from typing import Dict, List, Tuple
+from collections import Counter
 
 from pro_metrics import tokenize, compute_metrics, lowercase
 import pro_tune
@@ -72,9 +73,9 @@ class ProEngine:
         await self.save_state()
 
     def compute_charged_words(self, words: List[str]) -> List[str]:
+        word_counts = Counter(words)
         charges: Dict[str, float] = {}
-        for w in words:
-            freq = words.count(w)
+        for w, freq in word_counts.items():
             successors = len(self.state['bigram_counts'].get(w, {}))
             charges[w] = freq * (1 + successors)
         ordered = sorted(charges, key=charges.get, reverse=True)

--- a/tests/test_compute_charged_words_performance.py
+++ b/tests/test_compute_charged_words_performance.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import time
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from pro_engine import ProEngine  # noqa: E402
+
+
+def test_compute_charged_words_large_list_performance():
+    engine = ProEngine()
+    words = [f"word{i % 50}" for i in range(10000)]
+    start = time.perf_counter()
+    result = engine.compute_charged_words(words)
+    elapsed = time.perf_counter() - start
+    assert len(result) <= 5
+    assert elapsed < 1.0


### PR DESCRIPTION
## Summary
- use `collections.Counter` in `compute_charged_words` for efficient frequency counting
- derive word charges from precomputed counts
- add test ensuring `compute_charged_words` handles large word lists quickly

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d8a50ba88329b54d58986a8544d7