### PR TITLE
Handle dataset file removals in retraining trigger

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -60,7 +60,10 @@ class ProEngine:
         if os.path.exists(HASH_PATH):
             with open(HASH_PATH, 'r', encoding='utf-8') as fh:
                 old_hashes = json.load(fh)
-        changed = any(old_hashes.get(k) != v for k, v in new_hashes.items())
+        changed = (
+            set(old_hashes) != set(new_hashes)
+            or any(old_hashes.get(k) != v for k, v in new_hashes.items())
+        )
         with open(HASH_PATH, 'w', encoding='utf-8') as fh:
             json.dump(new_hashes, fh)
         if changed:

--- a/tests/test_dataset_removal_retrains.py
+++ b/tests/test_dataset_removal_retrains.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import asyncio
+
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from pro_engine import ProEngine  # noqa: E402
+
+
+def test_retrain_triggered_on_dataset_file_removal(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    datasets_dir = tmp_path / "datasets"
+    datasets_dir.mkdir()
+    data_file = datasets_dir / "sample.txt"
+    data_file.write_text("data")
+
+    engine = ProEngine()
+
+    calls = []
+
+    def fake_create_task(coro):
+        calls.append(coro)
+        coro.close()
+        loop = asyncio.get_running_loop()
+        return loop.create_task(asyncio.sleep(0))
+
+    monkeypatch.setattr(asyncio, "create_task", fake_create_task)
+
+    asyncio.run(engine.scan_datasets())
+    calls.clear()
+
+    data_file.unlink()
+
+    asyncio.run(engine.scan_datasets())
+    assert len(calls) == 1
+


### PR DESCRIPTION
## Summary
- detect when dataset files are removed and mark hashes as changed
- add regression test ensuring dataset removal triggers retraining

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dab669fc8329aa214fc0a9fe23d5