### PR TITLE
Add trigram and char n-gram tracking with metrics

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -19,12 +19,19 @@ LOG_PATH = 'pro.log'
 
 class ProEngine:
     def __init__(self) -> None:
-        self.state: Dict = {'word_counts': {}, 'bigram_counts': {}}
+        self.state: Dict = {
+            'word_counts': {},
+            'bigram_counts': {},
+            'trigram_counts': {},
+            'char_ngram_counts': {},
+        }
 
     async def setup(self) -> None:
         if os.path.exists(STATE_PATH):
             with open(STATE_PATH, 'r', encoding='utf-8') as fh:
                 self.state = json.load(fh)
+        for key in ['word_counts', 'bigram_counts', 'trigram_counts', 'char_ngram_counts']:
+            self.state.setdefault(key, {})
         if not self.state['word_counts']:
             try:
                 await asyncio.to_thread(
@@ -104,7 +111,11 @@ class ProEngine:
         context_tokens = tokenize(' '.join(context))
         all_words = words + lowercase(context_tokens)
         metrics = compute_metrics(
-            all_words, self.state['bigram_counts'], self.state['word_counts']
+            all_words,
+            self.state['trigram_counts'],
+            self.state['bigram_counts'],
+            self.state['word_counts'],
+            self.state['char_ngram_counts'],
         )
         charged = self.compute_charged_words(original_words + context_tokens)
         response = self.respond(charged)

--- a/pro_metrics.py
+++ b/pro_metrics.py
@@ -1,6 +1,7 @@
 import math
 import re
 from collections import Counter
+from typing import Dict, Tuple
 
 TOKEN_RE = re.compile(r"\b\w+\b")
 
@@ -41,6 +42,26 @@ def perplexity(words, bigram_counts, word_counts):
     return math.exp(log_prob / len(words))
 
 
+def trigram_perplexity(
+    words, trigram_counts: Dict[Tuple[str, str], Dict[str, int]], word_counts
+):
+    """Compute perplexity of words given a trigram model."""
+    if not words:
+        return 0.0
+    vocab = len(word_counts) or 1
+    log_prob = 0.0
+    prev2 = "<s>"
+    prev1 = "<s>"
+    for word in words:
+        prev_counts = trigram_counts.get((prev2, prev1), {})
+        numerator = prev_counts.get(word, 0) + 1
+        denominator = sum(prev_counts.values()) + vocab
+        prob = numerator / denominator
+        log_prob += -math.log(prob)
+        prev2, prev1 = prev1, word
+    return math.exp(log_prob / len(words))
+
+
 def resonance(words, bigram_counts):
     """Simple resonance metric: average bigram count along the sequence."""
     if not words:
@@ -53,9 +74,50 @@ def resonance(words, bigram_counts):
     return total / len(words)
 
 
-def compute_metrics(words, bigram_counts, word_counts):
+def trigram_resonance(
+    words, trigram_counts: Dict[Tuple[str, str], Dict[str, int]]
+):
+    """Average trigram count along the sequence."""
+    if not words:
+        return 0.0
+    total = 0
+    prev2 = "<s>"
+    prev1 = "<s>"
+    for word in words:
+        total += trigram_counts.get((prev2, prev1), {}).get(word, 0)
+        prev2, prev1 = prev1, word
+    return total / len(words)
+
+
+def char_ngram_resonance(words, char_counts, n: int = 3):
+    """Average character n-gram count across words."""
+    if not words:
+        return 0.0
+    total = 0
+    cnt = 0
+    for word in words:
+        for i in range(len(word) - n + 1):
+            ngram = word[i : i + n]
+            total += char_counts.get(ngram, 0)
+            cnt += 1
+    return total / cnt if cnt else 0.0
+
+
+def compute_metrics(
+    words,
+    trigram_counts,
+    bigram_counts,
+    word_counts,
+    char_ngram_counts,
+    char_n: int = 3,
+):
     return {
         "entropy": entropy(words),
         "perplexity": perplexity(words, bigram_counts, word_counts),
         "resonance": resonance(words, bigram_counts),
+        "trigram_perplexity": trigram_perplexity(words, trigram_counts, word_counts),
+        "trigram_resonance": trigram_resonance(words, trigram_counts),
+        "char_ngram_resonance": char_ngram_resonance(
+            words, char_ngram_counts, char_n
+        ),
     }

--- a/pro_sequence.py
+++ b/pro_sequence.py
@@ -1,13 +1,25 @@
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
-def analyze_sequences(state: Dict, words: List[str]) -> None:
-    """Update state with word and bigram counts."""
+
+def analyze_sequences(state: Dict, words: List[str], char_n: int = 3) -> None:
+    """Update state with word, bigram, trigram and char-level n-gram counts."""
     wc = state.setdefault('word_counts', {})
     bc = state.setdefault('bigram_counts', {})
-    prev = '<s>'
-    wc[prev] = wc.get(prev, 0) + 1
+    tc = state.setdefault('trigram_counts', {})
+    cnc = state.setdefault('char_ngram_counts', {}) if char_n else None
+    prev2 = '<s>'
+    prev1 = '<s>'
+    wc[prev1] = wc.get(prev1, 0) + 1
+    wc[prev2] = wc.get(prev2, 0) + 1
     for word in words:
         wc[word] = wc.get(word, 0) + 1
-        bc.setdefault(prev, {})
-        bc[prev][word] = bc[prev].get(word, 0) + 1
-        prev = word
+        bc.setdefault(prev1, {})
+        bc[prev1][word] = bc[prev1].get(word, 0) + 1
+        key: Tuple[str, str] = (prev2, prev1)
+        tc.setdefault(key, {})
+        tc[key][word] = tc[key].get(word, 0) + 1
+        if cnc is not None:
+            for i in range(len(word) - char_n + 1):
+                ngram = word[i : i + char_n]
+                cnc[ngram] = cnc.get(ngram, 0) + 1
+        prev2, prev1 = prev1, word

--- a/pro_tune.py
+++ b/pro_tune.py
@@ -3,6 +3,7 @@ import os
 from typing import Dict
 
 from pro_metrics import tokenize, lowercase
+import pro_sequence
 
 STATE_PATH = 'pro_state.json'
 
@@ -13,15 +14,7 @@ def train(state: Dict, dataset_path: str) -> Dict:
     with open(dataset_path, 'r', encoding='utf-8') as fh:
         text = fh.read()
     words = lowercase(tokenize(text))
-    wc = state.setdefault('word_counts', {})
-    bc = state.setdefault('bigram_counts', {})
-    prev = '<s>'
-    wc[prev] = wc.get(prev, 0) + 1
-    for word in words:
-        wc[word] = wc.get(word, 0) + 1
-        bc.setdefault(prev, {})
-        bc[prev][word] = bc[prev].get(word, 0) + 1
-        prev = word
+    pro_sequence.analyze_sequences(state, words)
     return state
 
 

--- a/tests/test_trigram_tracking.py
+++ b/tests/test_trigram_tracking.py
@@ -1,0 +1,21 @@
+import pro_sequence
+import pro_metrics
+
+
+def test_trigram_and_char_ngrams():
+    state = {}
+    words = ["one", "two", "three"]
+    pro_sequence.analyze_sequences(state, words)
+    assert state["trigram_counts"][('<s>', '<s>')]["one"] == 1
+    assert state["trigram_counts"][('<s>', 'one')]["two"] == 1
+    assert state["trigram_counts"][('one', 'two')]["three"] == 1
+    assert state["char_ngram_counts"]["one"] == 1
+    metrics = pro_metrics.compute_metrics(
+        words,
+        state["trigram_counts"],
+        state["bigram_counts"],
+        state["word_counts"],
+        state["char_ngram_counts"],
+    )
+    assert metrics["trigram_resonance"] > 0
+    assert metrics["char_ngram_resonance"] > 0


### PR DESCRIPTION
## Summary
- expand sequence analysis to record trigram and character n-gram frequencies
- expose trigram-based perplexity/resonance and character n-gram resonance metrics
- test trigram and char n-gram tracking

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1dbe739348329a5bb46f9ed6069a7