### PR TITLE
Add response formatting tests and configure CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,18 @@
+import pro_engine
+
+
+def test_response_structure_and_capitalization():
+    engine = pro_engine.ProEngine()
+    sentence = engine.respond(["hello", "WORLD"])
+    words = sentence.rstrip(".").split()
+    assert len(words) == 5
+    assert words[0][0].isupper()
+    assert sentence.endswith(".")
+    assert "WORLD" in words[1:]
+
+
+def test_preserves_first_word_capitalization():
+    engine = pro_engine.ProEngine()
+    sentence = engine.respond(["NASA", "launch", "window", "opens", "today"])
+    words = sentence.rstrip(".").split()
+    assert words[0] == "NASA"


### PR DESCRIPTION
## Summary
- test response has five words, capitalized first word, final period, and preserves user-provided capitals
- add GitHub Actions workflow to run tests on pushes and pull requests

## Testing
- `flake8 tests/test_response.py`
- `pytest`
- `flake8` *(fails: line too long and other style issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e41292cc83299ca64e1490d47b06