### PR TITLE
Add requirements for Nixpacks deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ __marimo__/
 pro_state.json
 dataset_sha.json
 pro.log
+pro_memory.db

--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ P.R.O. Pure Recursive Organism
 
 1. Copy `.env.example` to `.env` and replace the placeholder token.
 2. Run `python pro_tg.py` to start the bot. It echoes incoming messages using long polling.
+
+## Deployment
+
+Platforms such as [Railway](https://railway.app) use Nixpacks to detect a project's
+language and dependencies. An empty `requirements.txt` file is included so the
+app is recognized as a Python project during deployment. Add any runtime
+dependencies to that file as your project evolves.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# This file ensures Nixpacks detects the app as Python.
+# Add runtime dependencies here when needed.

--- a/tests/test_engine_resilience.py
+++ b/tests/test_engine_resilience.py
@@ -1,4 +1,3 @@
-import asyncio
 import pytest
 import pro_engine
 import pro_memory


### PR DESCRIPTION
## Summary
- add blank `requirements.txt` so Nixpacks detects Python app
- document Railway deployment using Nixpacks
- ignore generated `pro_memory.db` and clean up unused test import

## Testing
- `python -m pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea424a9483299bf46db0e691c897