### PR TITLE
Log training errors and warn when initial dataset missing

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -38,13 +38,23 @@ class ProEngine:
         ]:
             self.state.setdefault(key, {})
         if not self.state['word_counts']:
-            try:
-                await asyncio.to_thread(
-                    pro_tune.train, self.state, 'datasets/lines01.txt'
-                )  # noqa: E501
-                await self.save_state()
-            except Exception:
-                pass
+            dataset_path = 'datasets/lines01.txt'
+            if os.path.exists(dataset_path):
+                try:
+                    await asyncio.to_thread(
+                        pro_tune.train, self.state, dataset_path
+                    )  # noqa: E501
+                    await self.save_state()
+                except Exception as exc:
+                    logging.error(
+                        "Initial training failed: %s", exc
+                    )  # pragma: no cover - logging side effect
+            else:
+                logging.warning(
+                    "Dataset path %s does not exist; "
+                    "skipping initial training",
+                    dataset_path,
+                )
         await pro_memory.init_db()
         logging.basicConfig(
             filename=LOG_PATH, level=logging.INFO, format='%(message)s'


### PR DESCRIPTION
## Summary
- Log initial training failures during setup instead of silently passing
- Warn and skip training when the initial dataset file is absent

## Testing
- `flake8 pro_engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1f316f4ac83299d87fdbcf1b8b90d