### PR TITLE
Enable trigram-based word prediction for responses

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,31 +1,36 @@
 import pro_engine
 
 
-def test_response_structure_and_capitalization():
+def test_response_uses_trigram_prediction():
     engine = pro_engine.ProEngine()
+    engine.state["trigram_counts"] = {
+        ("hello", "WORLD"): {"foo": 2},
+        ("WORLD", "foo"): {"bar": 3},
+        ("foo", "bar"): {"baz": 4},
+    }
+    engine.state["word_counts"] = {"foo": 2, "bar": 3, "baz": 4}
     sentence = engine.respond(["hello", "WORLD"])
-    words = sentence.rstrip(".").split()
-    assert len(words) == 5
-    assert words[0][0].isupper()
-    assert sentence.endswith(".")
-    assert "WORLD" in words[1:]
+    assert sentence == "Hello WORLD foo bar baz."
+
+
+def test_predict_next_word_fallback_to_bigram():
+    engine = pro_engine.ProEngine()
+    engine.state["bigram_counts"] = {"world": {"hello": 2}}
+    engine.state["word_counts"] = {"hello": 2}
+    assert engine.predict_next_word("x", "world") == "hello"
 
 
 def test_preserves_first_word_capitalization():
     engine = pro_engine.ProEngine()
-    sentence = engine.respond(["NASA", "launch", "window", "opens", "today"])
-    words = sentence.rstrip(".").split()
-    assert words[0] == "NASA"
-
-
-def test_fills_from_state_without_duplicates():
-    engine = pro_engine.ProEngine()
-    engine.state["word_counts"] = {
-        "alpha": 5,
-        "beta": 4,
-        "gamma": 3,
-        "delta": 2,
+    engine.state["trigram_counts"] = {
+        ("nasa", "launch"): {"window": 1},
+        ("launch", "window"): {"opens": 1},
+        ("window", "opens"): {"today": 1},
     }
-    sentence = engine.respond(["hello"])
-    words = sentence.rstrip(".").split()
-    assert words == ["Hello", "alpha", "beta", "gamma", "delta"]
+    engine.state["word_counts"] = {
+        "window": 1,
+        "opens": 1,
+        "today": 1,
+    }
+    sentence = engine.respond(["NASA", "launch"])
+    assert sentence == "NASA launch window opens today."


### PR DESCRIPTION
## Summary
- add `predict_next_word` using trigram counts with bigram and unigram fallbacks
- build sentences in `respond` by iteratively predicting next words
- update `process_message` to seed responses with user and context words
- exercise new functionality in tests

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f3c92b348329bffae59f9cff8e11