### PR TITLE
Monitor datasets and retrain on changes

### DIFF
--- a/tests/test_dataset_scan_tunes.py
+++ b/tests/test_dataset_scan_tunes.py
@@ -1,0 +1,68 @@
+import asyncio
+import logging
+import os
+from pro_engine import ProEngine
+import pro_tune
+
+
+def test_scan_triggers_tune_on_change(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    datasets_dir = tmp_path / "datasets"
+    datasets_dir.mkdir()
+    data_file = datasets_dir / "sample.txt"
+    data_file.write_text("one")
+
+    engine = ProEngine()
+    called = []
+
+    async def fake_async_tune(paths):
+        called.extend(paths)
+
+    monkeypatch.setattr(engine, "_async_tune", fake_async_tune)
+
+    async def run_scan():
+        await engine.scan_datasets()
+        await asyncio.sleep(0)
+
+    asyncio.run(run_scan())
+    expected = os.path.join("datasets", "sample.txt")
+    assert called == [expected]
+
+    called.clear()
+    data_file.write_text("two")
+    asyncio.run(run_scan())
+    assert called == [expected]
+
+
+def test_async_tune_logs_and_saves(tmp_path, monkeypatch):
+    data_file = tmp_path / "sample.txt"
+    data_file.write_text("data")
+
+    engine = ProEngine()
+
+    trained = []
+
+    def fake_train(state, path):
+        trained.append(path)
+
+    monkeypatch.setattr(pro_tune, "train", fake_train)
+
+    saved = []
+
+    async def fake_save_state():
+        saved.append(True)
+
+    monkeypatch.setattr(engine, "save_state", fake_save_state)
+
+    logs = []
+
+    def fake_info(msg, *args):
+        logs.append(msg % args)
+
+    monkeypatch.setattr(logging, "info", fake_info)
+
+    asyncio.run(engine._async_tune([str(data_file)]))
+
+    assert trained == [str(data_file)]
+    assert saved
+    assert any("sample.txt" in entry for entry in logs)

--- a/tests/test_engine_resilience.py
+++ b/tests/test_engine_resilience.py
@@ -1,14 +1,13 @@
-import pytest
+import asyncio
 import pro_engine
 import pro_memory
 import pro_rag
 import pro_tune
 
 
-@pytest.mark.asyncio
-async def test_process_message_resilience(monkeypatch):
+def test_process_message_resilience(monkeypatch):
     engine = pro_engine.ProEngine()
-    await engine.setup()
+    asyncio.run(engine.setup())
 
     orig_add = pro_memory.add_message
     orig_retrieve = pro_rag.retrieve
@@ -22,20 +21,19 @@ async def test_process_message_resilience(monkeypatch):
     monkeypatch.setattr(pro_memory, "add_message", failing_add_message)
     monkeypatch.setattr(pro_rag, "retrieve", failing_retrieve)
 
-    response, metrics = await engine.process_message("hello world")
+    response, metrics = asyncio.run(engine.process_message("hello world"))
     assert isinstance(response, str)
     assert isinstance(metrics, dict)
 
     monkeypatch.setattr(pro_memory, "add_message", orig_add)
     monkeypatch.setattr(pro_rag, "retrieve", orig_retrieve)
 
-    response2, metrics2 = await engine.process_message("second message")
+    response2, metrics2 = asyncio.run(engine.process_message("second message"))
     assert isinstance(response2, str)
     assert isinstance(metrics2, dict)
 
 
-@pytest.mark.asyncio
-async def test_async_tune_resilience(monkeypatch):
+def test_async_tune_resilience(monkeypatch):
     engine = pro_engine.ProEngine()
 
     def failing_train(state, path):
@@ -43,4 +41,4 @@ async def test_async_tune_resilience(monkeypatch):
 
     monkeypatch.setattr(pro_tune, "train", failing_train)
 
-    await engine._async_tune()
+    asyncio.run(engine._async_tune(["dummy"]))


### PR DESCRIPTION
## Summary
- watch dataset directory periodically and retrain when files change
- persist state and log tuned datasets
- add tests for dataset scanning and logging, update resilience tests

## Testing
- `python -m flake8 pro_engine.py tests/test_engine_resilience.py tests/test_dataset_scan_tunes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1f416d9c88329a5628aa470e9ea5e