### PR TITLE
Log missing or empty dataset during setup

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -41,15 +41,22 @@ class ProEngine:
         if not self.state['word_counts']:
             dataset_path = 'datasets/lines01.txt'
             if os.path.exists(dataset_path):
-                try:
-                    await asyncio.to_thread(
-                        pro_tune.train, self.state, dataset_path
-                    )  # noqa: E501
-                    await self.save_state()
-                except Exception as exc:
-                    logging.error(
-                        "Initial training failed: %s", exc
-                    )  # pragma: no cover - logging side effect
+                if os.path.getsize(dataset_path) > 0:
+                    try:
+                        await asyncio.to_thread(
+                            pro_tune.train, self.state, dataset_path
+                        )  # noqa: E501
+                        await self.save_state()
+                    except Exception as exc:
+                        logging.error(
+                            "Initial training failed: %s", exc
+                        )  # pragma: no cover - logging side effect
+                else:
+                    logging.warning(
+                        "Dataset path %s is empty; "
+                        "skipping initial training",
+                        dataset_path,
+                    )
             else:
                 logging.warning(
                     "Dataset path %s does not exist; "


### PR DESCRIPTION
## Summary
- warn when initial dataset file is missing or empty
- ensure initial training errors are logged for visibility

## Testing
- `python -m flake8 pro_engine.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1fc7f3d408329a3370829d278e37d