### PR TITLE
Ensure unique responses and persist history

### DIFF
--- a/pro_memory.py
+++ b/pro_memory.py
@@ -4,15 +4,26 @@ from typing import List
 
 DB_PATH = 'pro_memory.db'
 
+
 async def init_db() -> None:
     """Initialize sqlite database."""
-    def _setup():
+
+    def _setup() -> None:
         conn = sqlite3.connect(DB_PATH)
         cur = conn.cursor()
-        cur.execute('CREATE TABLE IF NOT EXISTS messages(id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)')
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS messages("  # noqa: E501
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)"
+        )
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS responses("  # noqa: E501
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT)"
+        )
         conn.commit()
         conn.close()
+
     await asyncio.to_thread(_setup)
+
 
 async def add_message(content: str) -> None:
     """Store a message asynchronously."""
@@ -24,12 +35,38 @@ async def add_message(content: str) -> None:
         conn.close()
     await asyncio.to_thread(_write)
 
+
+def is_unique(sentence: str) -> bool:
+    """Return True if sentence not already stored."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        'SELECT 1 FROM responses WHERE content = ? LIMIT 1',
+        (sentence,),
+    )
+    exists = cur.fetchone()
+    conn.close()
+    return exists is None
+
+
+def store_response(sentence: str) -> None:
+    """Persist a generated response synchronously."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute('INSERT INTO responses(content) VALUES (?)', (sentence,))
+    conn.commit()
+    conn.close()
+
+
 async def fetch_recent(limit: int = 5) -> List[str]:
     """Fetch recent messages for context."""
     def _read() -> List[str]:
         conn = sqlite3.connect(DB_PATH)
         cur = conn.cursor()
-        cur.execute('SELECT content FROM messages ORDER BY id DESC LIMIT ?', (limit,))
+        cur.execute(
+            'SELECT content FROM messages ORDER BY id DESC LIMIT ?',
+            (limit,),
+        )
         rows = cur.fetchall()
         conn.close()
         return [r[0] for r in rows][::-1]

--- a/tests/test_memory_rag_integration.py
+++ b/tests/test_memory_rag_integration.py
@@ -70,5 +70,5 @@ def test_sqlite_connection_open_close(engine, monkeypatch):
     monkeypatch.setattr(sqlite3, "connect", tracking_connect)
 
     asyncio.run(engine.process_message("another message"))
-    assert counts["connect"] == 3
-    assert counts["close"] == 3
+    assert counts["connect"] == 5
+    assert counts["close"] == 5


### PR DESCRIPTION
## Summary
- Track generated responses in a new SQLite `responses` table
- Prevent duplicate replies by checking history and regenerating until unique
- Test duplicate suppression and update connection-count expectations

## Testing
- `python -m flake8 pro_engine.py pro_memory.py tests/test_response.py tests/test_memory_rag_integration.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b217f277cc83299cd2fb6d02df137b