### PR TITLE
Update predictive graph incrementally

### DIFF
--- a/pro_engine.py
+++ b/pro_engine.py
@@ -352,6 +352,7 @@ class ProEngine:
             self.state,
             lowercase(tokenize(response)),
         )
+        await pro_predict.update(words + lowercase(tokenize(response)))
         try:
             await self.save_state()
         except Exception as exc:  # pragma: no cover - logging side effect

--- a/pro_predict.py
+++ b/pro_predict.py
@@ -51,6 +51,25 @@ def _ensure_vectors() -> None:
     _VECTORS = _build_embeddings(_GRAPH)
 
 
+async def update(word_list: List[str]) -> None:
+    """Update the co-occurrence graph and vectors with new words.
+
+    The *word_list* should contain individual tokens. After the update the
+    words become part of the internal vocabulary used by :func:`suggest`.
+    """
+    global _VECTORS
+    _ensure_vectors()
+    words = lowercase(word_list)
+    for i, word in enumerate(words):
+        for j in range(i + 1, len(words)):
+            other = words[j]
+            if not word or not other:
+                continue
+            _GRAPH.setdefault(word, Counter())[other] += 1
+            _GRAPH.setdefault(other, Counter())[word] += 1
+    _VECTORS = _build_embeddings(_GRAPH)
+
+
 def suggest(word: str, topn: int = 3) -> List[str]:
     """Return up to *topn* words semantically close to *word*.
 

--- a/tests/test_predict_update.py
+++ b/tests/test_predict_update.py
@@ -1,0 +1,33 @@
+import asyncio
+import pro_engine
+import pro_memory
+import pro_predict
+import pro_rag
+
+
+def test_predict_learns_new_words(tmp_path, monkeypatch):
+    db_path = tmp_path / "mem.db"
+    monkeypatch.setattr(pro_memory, "DB_PATH", str(db_path))
+    asyncio.run(pro_memory.init_db())
+
+    engine = pro_engine.ProEngine()
+
+    monkeypatch.setattr(pro_engine.ProEngine, "respond", lambda self, seeds: "music")
+
+    async def dummy_retrieve(words, limit=5):
+        return []
+
+    monkeypatch.setattr(pro_rag, "retrieve", dummy_retrieve)
+
+    asyncio.run(engine.setup())
+
+    new_word = "zzzzword"
+    assert new_word not in pro_predict._VECTORS
+    before = pro_predict.suggest(new_word)
+
+    asyncio.run(engine.process_message(f"{new_word} music"))
+
+    assert new_word in pro_predict._VECTORS
+    after = pro_predict.suggest(new_word)
+    assert after != before
+    assert after


### PR DESCRIPTION
## Summary
- add async `pro_predict.update` to learn word co-occurrences on the fly
- call `update` from `process_message` with user and response tokens
- test that new words become suggestible after a message is processed

## Testing
- `python -m pyflakes pro_predict.py pro_engine.py tests/test_predict_update.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b21ef181908329b67cfe1268d90d18