### PR TITLE
Integrate tiny NumPy self-attention predictor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-asyncio
+numpy

--- a/tests/test_transformer_integration.py
+++ b/tests/test_transformer_integration.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pro_engine
+import pro_memory
+import pro_predict
+import pro_rag
+
+
+def test_mini_transformer_logits():
+    vocab = ["a", "b", "c"]
+    logits = pro_predict.transformer_logits(["a", "b"], vocab)
+    assert set(logits) == set(vocab)
+
+
+def test_process_message_blends_transformer(tmp_path, monkeypatch):
+    db_path = tmp_path / "mem.db"
+    monkeypatch.setattr(pro_memory, "DB_PATH", str(db_path))
+    asyncio.run(pro_memory.init_db())
+    engine = pro_engine.ProEngine()
+    engine.state["word_counts"] = {"hello": 1, "world": 1, "foo": 1, "baz": 1}
+    engine.state["bigram_counts"] = {"world": {"foo": 1}}
+    engine.state["trigram_counts"] = {("hello", "world"): {"foo": 1}}
+    monkeypatch.setattr(pro_rag, "retrieve", lambda words: [])
+
+    called = {}
+
+    def fake_transformer(tokens, vocab):
+        called["tokens"] = list(tokens)
+        return {"baz": 1.0}
+
+    monkeypatch.setattr(pro_predict, "transformer_logits", fake_transformer)
+
+    captured = {}
+
+    def fake_respond(seed_words):
+        captured["seed_words"] = list(seed_words)
+        return "ok"
+
+    engine.respond = fake_respond
+    asyncio.run(engine.process_message("hello world"))
+    assert called["tokens"] == ["hello", "world"]
+    assert "foo" in captured["seed_words"]
+    assert "baz" in captured["seed_words"]


### PR DESCRIPTION
## Summary
- add `MiniSelfAttention` using NumPy for next-word logits
- blend transformer and n-gram predictions during `process_message`
- cover transformer path with integration tests

## Testing
- `python -m py_compile pro_predict.py pro_engine.py tests/test_transformer_integration.py`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b224692120832986cf283665ddfd53